### PR TITLE
Potential fix for lock-up with Windows Bluetooth serial ports

### DIFF
--- a/serial_windows.go
+++ b/serial_windows.go
@@ -427,9 +427,11 @@ func nativeOpen(portName string, mode *Mode) (*windowsPort, error) {
 	}
 
 	timeouts := &commTimeouts{
-		ReadIntervalTimeout:        0xFFFFFFFF,
-		ReadTotalTimeoutMultiplier: 0xFFFFFFFF,
-		ReadTotalTimeoutConstant:   0xFFFFFFFF - 1,
+		ReadIntervalTimeout:         0xFFFFFFFF,
+		ReadTotalTimeoutMultiplier:  0xFFFFFFFF,
+		ReadTotalTimeoutConstant:    0xFFFFFFFF - 1,
+		WriteTotalTimeoutConstant:   10000,
+		WriteTotalTimeoutMultiplier: 0,
 	}
 	if setCommTimeouts(port.handle, timeouts) != nil {
 		port.Close()


### PR DESCRIPTION
The Bluetooth problem isn't opening the port, it's that it's a read-only port. The first write from ZML blocks forever.

This change results in a NoDeviceFound exception from ZML, which seems reasonable to me.

Maybe the timeout should be larger or made configurable though?
