### PR TITLE
Cancelling all pending operation on closing (win).

### DIFF
--- a/serial_windows.go
+++ b/serial_windows.go
@@ -72,6 +72,8 @@ func (port *windowsPort) Close() error {
 		defer syscall.CloseHandle(port.readOverlapped.HEvent)
 	}
 
+	_ = syscall.CancelIoEx(port.handle, nil)
+
 	// implementation inspired by
 	// https://referencesource.microsoft.com/#system/sys/system/io/ports/SerialPort.cs
 	// Unless the code below is executed the CloseHandle does not close the port properly.


### PR DESCRIPTION
We have discovered that some serial ports on Windows are not writable. On such ports, the write operation will block forever. We can deal with the issue on the application level with timeouts. But even the closing of the port blocks forever because of the FlushFileBuffers call. There is no method that would allow us to unblock our code in such a scenario. We decided that for our use case, the close operation should cancel any pending operations. It's up to the higher-level code to ensure that write has finished before closing or otherwise deal with the consequences.